### PR TITLE
fix(GH-1): don't ignore `pom` input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,4 +21,9 @@ runs:
     - id: resolve-version
       shell: bash
       run: "echo \"::set-output name=resolved-version::\
-        $(mvn -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec --quiet)\""
+        $(mvn
+          --file ${{ inputs.pom }}
+          -Dexec.executable=echo
+          -Dexec.args='${project.version}'
+          --non-recursive exec:exec --quiet
+        )\""


### PR DESCRIPTION
# Description

This resolves an issue due to which the `pom` input was ignored.

# References

This resolves GH-1