### PR TITLE
feat: update to GitHub Actions API `2.298.2`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,10 +22,10 @@ runs:
   steps:
     - id: resolve-version
       shell: bash
-      run: "echo \"::set-output name=resolved-version::\
+      run: "echo \"name=resolved-version::\
         $(mvn
           ${{ inputs.pom != '' && format('--file={0}', inputs.pom) || '' }}
           ${{ inputs.settings != '' && format('--settings={0}', inputs.settings) || '' }}
           --quiet --non-recursive
           exec:exec -Dexec.executable=echo -Dexec.args='${project.version}'
-        )\""
+        )\" >> \"${GITHUB_OUTPUT}\""


### PR DESCRIPTION
Accrording to the [blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), writing to outputs via `::set-output` is now deprecated and should be replaced with writing to `$GITHUB_OUTPUT` file.